### PR TITLE
Updates to CLI "brain ls" output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,8 +81,8 @@ explicitly: ``brain --stream-endpoint=... ls``
 
 Usage::
 
-    $ brain ls (shows playable stations)
-    +Available Stations------------+-----------------------+--------+
+    $ brain ls
+    +Playable Stations-------------+-----------------------+--------+
     | id  | name                   | string_id             | length |
     +-----+------------------------+-----------------------+--------+
     | 32  | Quick Relax            | relax.justrelax15min  | 15     |
@@ -94,16 +94,16 @@ Usage::
     | 541 | LoFi Focus             | explore.focus.lowfi   | 30     |
     +-----+------------------------+-----------------------+--------+
 
-    $ brain ls -a (shows all stations)
-    +Available Stations------------+-----------------------+--------+
+    $ brain ls -a
+    +All Stations------------------+-----------------------+--------+
     | id  | name                   | string_id             | length |
     +-----+------------------------+-----------------------+--------+
-    | 0   | Favorites              | None                  | 0      |
+    | 0   | Favorites              | None                  | None   |
     | 32  | Quick Relax            | relax.justrelax15min  | 15     |
     | 34  | Relaxed Focus          | explore.relaxed       | 30     |
     | ... | ...                    | ...                   | ...    |
-    | 46  | Explore                | explore               | 0      |
-    | 47  | Explore Relax          | explore.relax         | 0      |
+    | 46  | Explore                | explore               | None   |
+    | 47  | Explore Relax          | explore.relax         | None   |
     | ... | ...                    | ...                   | ...    |
     | 541 | LoFi Focus             | explore.focus.lowfi   | 30     |
     +-----+------------------------+-----------------------+--------+

--- a/README.rst
+++ b/README.rst
@@ -82,31 +82,31 @@ explicitly: ``brain --stream-endpoint=... ls``
 Usage::
 
     $ brain ls
-    +Playable Stations-------------+-----------------------+--------+
-    | id  | name                   | string_id             | length |
-    +-----+------------------------+-----------------------+--------+
-    | 32  | Quick Relax            | relax.justrelax15min  | 15     |
-    | 34  | Relaxed Focus          | explore.relaxed       | 30     |
-    | 35  | Focus                  | focus.3               | 30     |
-    | 36  | Sleep                  | sleep                 | 45     |
-    | ... | ...                    | ...                   | ...    |
-    | 540 | Study Focus            | explore.focus.study   | 30     |
-    | 541 | LoFi Focus             | explore.focus.lowfi   | 30     |
-    +-----+------------------------+-----------------------+--------+
+    +Playable Stations-------------+-----------------------+-------- +
+    | id  | name                   | string_id             | length  |
+    +-----+------------------------+-----------------------+-------- +
+    | 32  | Quick Relax            | relax.justrelax15min  | 15 mins |
+    | 34  | Relaxed Focus          | explore.relaxed       | 30 mins |
+    | 35  | Focus                  | focus.3               | 30 mins |
+    | 36  | Sleep                  | sleep                 | 45 mins |
+    | ... | ...                    | ...                   | ...     |
+    | 540 | Study Focus            | explore.focus.study   | 30 mins |
+    | 541 | LoFi Focus             | explore.focus.lowfi   | 30 mins |
+    +-----+------------------------+-----------------------+-------- +
 
     $ brain ls -a
-    +All Stations------------------+-----------------------+--------+
-    | id  | name                   | string_id             | length |
-    +-----+------------------------+-----------------------+--------+
-    | 0   | Favorites              | None                  | None   |
-    | 32  | Quick Relax            | relax.justrelax15min  | 15     |
-    | 34  | Relaxed Focus          | explore.relaxed       | 30     |
-    | ... | ...                    | ...                   | ...    |
-    | 46  | Explore                | explore               | None   |
-    | 47  | Explore Relax          | explore.relax         | None   |
-    | ... | ...                    | ...                   | ...    |
-    | 541 | LoFi Focus             | explore.focus.lowfi   | 30     |
-    +-----+------------------------+-----------------------+--------+
+    +All Stations------------------+-----------------------+-------- +
+    | id  | name                   | string_id             | length  |
+    +-----+------------------------+-----------------------+-------- +
+    | 0   | Favorites              | None                  | None    |
+    | 32  | Quick Relax            | relax.justrelax15min  | 15 mins |
+    | 34  | Relaxed Focus          | explore.relaxed       | 30 mins |
+    | ... | ...                    | ...                   | ...     |
+    | 46  | Explore                | explore               | None    |
+    | 47  | Explore Relax          | explore.relax         | None    |
+    | ... | ...                    | ...                   | ...     |
+    | 541 | LoFi Focus             | explore.focus.lowfi   | 30 mins |
+    +-----+------------------------+-----------------------+-------- +
 
     $ brain gt 60
     3ff0eab0-a5f6-11e6-a5c2-f11c700a6178

--- a/README.rst
+++ b/README.rst
@@ -82,17 +82,17 @@ explicitly: ``brain --stream-endpoint=... ls``
 Usage::
 
     $ brain ls
-    +Available Stations------------+---------------------------+
-    | id  | name                   | string_id                 |
-    +-----+------------------------+---------------------------+
-    | 34  | Relaxed Focus          | explore.relaxed           |
-    | 53  | Beach Focus            | explore.focus.beach       |
-    | 54  | Chimes & Bowls Focus   | explore.focus.bells       |
-    | 55  | Electronic Music Focus | explore.focus.electronic  |
-    | ... | ...                    | ...                       |
-    | 262 | Wind Relax             | explore.relax.wind        |
-    | 300 | Cinematic Music Focus  | explore.focus.cinematic   |
-    +-----+------------------------+---------------------------+
+    +Available Stations------------+-----------------------+--------+
+    | id  | name                   | string_id             | length |
+    +-----+------------------------+-----------------------+--------+
+    | 32  | Quick Relax            | relax.justrelax15min  | 15     |
+    | 34  | Relaxed Focus          | explore.relaxed       | 30     |
+    | 35  | Focus                  | focus.3               | 30     |
+    | 36  | Sleep                  | sleep                 | 45     |
+    | ... | ...                    | ...                   | ...    |
+    | 540 | Study Focus            | explore.focus.study   | 30     |
+    | 541 | LoFi Focus             | explore.focus.lowfi   | 30     |
+    +-----+------------------------+-----------------------+--------+
 
     $ brain gt 60
     3ff0eab0-a5f6-11e6-a5c2-f11c700a6178

--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ explicitly: ``brain --stream-endpoint=... ls``
 
 Usage::
 
-    $ brain ls
+    $ brain ls (shows playable stations)
     +Available Stations------------+-----------------------+--------+
     | id  | name                   | string_id             | length |
     +-----+------------------------+-----------------------+--------+
@@ -91,6 +91,20 @@ Usage::
     | 36  | Sleep                  | sleep                 | 45     |
     | ... | ...                    | ...                   | ...    |
     | 540 | Study Focus            | explore.focus.study   | 30     |
+    | 541 | LoFi Focus             | explore.focus.lowfi   | 30     |
+    +-----+------------------------+-----------------------+--------+
+
+    $ brain ls -a (shows all stations)
+    +Available Stations------------+-----------------------+--------+
+    | id  | name                   | string_id             | length |
+    +-----+------------------------+-----------------------+--------+
+    | 0   | Favorites              | None                  | 0      |
+    | 32  | Quick Relax            | relax.justrelax15min  | 15     |
+    | 34  | Relaxed Focus          | explore.relaxed       | 30     |
+    | ... | ...                    | ...                   | ...    |
+    | 46  | Explore                | explore               | 0      |
+    | 47  | Explore Relax          | explore.relax         | 0      |
+    | ... | ...                    | ...                   | ...    |
     | 541 | LoFi Focus             | explore.focus.lowfi   | 30     |
     +-----+------------------------+-----------------------+--------+
 

--- a/brainfm/__init__.py
+++ b/brainfm/__init__.py
@@ -3,7 +3,7 @@ import re
 import requests
 
 
-__version__ = "3.2.0"
+__version__ = "3.3.0"
 
 __all__ = [
     "BROWSER",

--- a/brainfm/__init__.py
+++ b/brainfm/__init__.py
@@ -3,7 +3,7 @@ import re
 import requests
 
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"
 
 __all__ = [
     "BROWSER",

--- a/brainfm/__init__.py
+++ b/brainfm/__init__.py
@@ -3,7 +3,7 @@ import re
 import requests
 
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"
 
 __all__ = [
     "BROWSER",

--- a/brainfm/__init__.py
+++ b/brainfm/__init__.py
@@ -3,7 +3,7 @@ import re
 import requests
 
 
-__version__ = "2.0.0"
+__version__ = "3.0.0"
 
 __all__ = [
     "BROWSER",

--- a/brainfm/main/cli.py
+++ b/brainfm/main/cli.py
@@ -12,7 +12,7 @@ import brainfm
 ENVKEY_SID = "BRAINFM_SID"
 ENVKEY_API_ENDPOINT = "BRAINFM_API_ENDPOINT"
 ENVKEY_STREAM_ENDPOINT = "BRAINFM_STREAM_ENDPOINT"
-STATIONS_PATTERN = jmespath.compile("[*].[id, name, string_id]")
+STATIONS_PATTERN = jmespath.compile("[*].[id, name, string_id, length]")
 
 
 def validate_client(client: brainfm.Connection):
@@ -70,8 +70,9 @@ def ls(client: brainfm.Connection):
     """List stations"""
     validate_client(client)
     stations = client.list_stations()
-    headers = ["id", "name", "string_id"]
+    headers = ["id", "name", "string_id", "length"]
     data = sorted(STATIONS_PATTERN.search(stations))
+    data = [station for station in data if station[3]]
     table = terminaltables.AsciiTable(
         table_data=[headers] + data,
         title="Available Stations")

--- a/brainfm/main/cli.py
+++ b/brainfm/main/cli.py
@@ -66,13 +66,15 @@ def details(client: brainfm.Connection):
 
 @cli.command()
 @click.pass_obj
-def ls(client: brainfm.Connection):
+@click.option("-a", is_flag=True, default=False)
+def ls(client: brainfm.Connection, a):
     """List stations"""
     validate_client(client)
     stations = client.list_stations()
     headers = ["id", "name", "string_id", "length"]
     data = sorted(STATIONS_PATTERN.search(stations))
-    data = [station for station in data if station[3]]
+    if not a:
+        data = [station for station in data if station[3]]
     table = terminaltables.AsciiTable(
         table_data=[headers] + data,
         title="Available Stations")

--- a/brainfm/main/cli.py
+++ b/brainfm/main/cli.py
@@ -73,11 +73,18 @@ def ls(client: brainfm.Connection, a):
     stations = client.list_stations()
     headers = ["id", "name", "string_id", "length"]
     data = sorted(STATIONS_PATTERN.search(stations))
-    if not a:
+    ls_title = "Available Stations"
+    if a:
+        ls_title = "All Stations"
+        for i, station in enumerate(data[:]):
+            if not station[3]:
+                data[i][3] = "None"
+    else:
+        ls_title = "Playable Stations"
         data = [station for station in data if station[3]]
     table = terminaltables.AsciiTable(
         table_data=[headers] + data,
-        title="Available Stations")
+        title=ls_title)
     print(table.table)
 
 

--- a/brainfm/main/cli.py
+++ b/brainfm/main/cli.py
@@ -76,12 +76,19 @@ def ls(client: brainfm.Connection, a):
     ls_title = "Available Stations"
     if a:
         ls_title = "All Stations"
-        for i, station in enumerate(data[:]):
-            if not station[3]:
-                data[i][3] = "None"
     else:
         ls_title = "Playable Stations"
         data = [station for station in data if station[3]]
+    for i, station in enumerate(data[:]):
+        duration = int(station[3])
+        if duration == 0:
+            data[i][3] = "None"
+        elif duration == 60:
+            data[i][3] = "1 hr"
+        elif duration > 60:
+            data[i][3] = str(int(duration / 60)) + " hrs"
+        else:
+            data[i][3] = str(duration) + " mins"
     table = terminaltables.AsciiTable(
         table_data=[headers] + data,
         title=ls_title)


### PR DESCRIPTION
Addresses Issue #17.

The new default behavior when using `brain ls` is to only show stations that have a nonzero "length" value; _all_ the results that are returned can be played. The old behavior (show all IDs) is available with the new `brain ls -a` command (based on the GNU `ls` syntax).

A new column has been added, also, with the "length" (duration) for each station, formated in hr/min amounts. Each commit adds/changes the output for the "length" column a little bit. Each one might be a breaking change, but they are being all submitted at the same time. Therefore, the new version number `3.3.0`.